### PR TITLE
Add config to enable customers (users)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ ${APP_DIR}/node_modules: yarn.install
 ### TESTS
 ### ¯¯¯¯¯
 
+test.all: test.composer test.phpstan test.phpunit test.phpspec test.phpcs test.yaml test.schema test.twig ## Run all tests in once
+
 test.composer: ## Validate composer.json
 	${COMPOSER} validate --strict
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console
 export COMPOSE_PROJECT_NAME=no-commerce
 COMPOSE=docker-compose
-YARN=cd ${APP_DIR} && yarn
+YARN=yarn
 PHPSTAN=symfony php vendor/bin/phpstan
 PHPUNIT=symfony php vendor/bin/phpunit
 PHPSPEC=symfony php vendor/bin/phpspec
@@ -51,9 +51,8 @@ endif
 yarn.install: ${APP_DIR}/yarn.lock
 
 ${APP_DIR}/yarn.lock:
-	${YARN} install
 	ln -sf ${APP_DIR}/node_modules node_modules
-	${YARN} encore dev
+	cd ${APP_DIR} && ${YARN} install && ${YARN} build
 
 node_modules: ${APP_DIR}/node_modules ## Install the Node dependencies using yarn
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ Then create the config file in `config/packages/monsieurbiz_sylius_nocommerce_pl
 ```yaml
 imports:
     - { resource: "@MonsieurBizSyliusNoCommercePlugin/Resources/config/config.yaml" }
+
+monsieurbiz_sylius_nocommerce:
+    config:
+        allow_customers: false
 ```
+
+You can allow customers by changing the `allow_customers` parameters to `true`.
 
 Add some annotations to your `src/Entity/Channel/Channel.php` entity to prevent error during Channel saving:
 

--- a/recipes/1.0/config/packages/monsieurbiz_sylius_nocommerce_plugin.yaml
+++ b/recipes/1.0/config/packages/monsieurbiz_sylius_nocommerce_plugin.yaml
@@ -1,2 +1,6 @@
 imports:
     - { resource: "@MonsieurBizSyliusNoCommercePlugin/Resources/config/config.yaml" }
+
+monsieurbiz_sylius_nocommerce:
+    config:
+        allow_customers: false

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -36,7 +36,7 @@ final class Configuration implements ConfigurationInterface
             // Config
             ->arrayNode('config')
                 ->children()
-                    ->booleanNode('allow_customers')->isRequired()->defaultValue(false)->end()
+                    ->booleanNode('allow_customers')->isRequired()->end()
                 ->end()
             ->end()
         ;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,12 +24,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('monsieurbiz_sylius_nocommerce');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('monsieur_biz_sylius_search');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,6 +23,24 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        return new TreeBuilder('monsieurbiz_sylius_nocommerce');
+        $treeBuilder = new TreeBuilder('monsieurbiz_sylius_nocommerce');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('monsieur_biz_sylius_search');
+        }
+
+        $rootNode
+            ->children()
+            // Config
+            ->arrayNode('config')
+                ->children()
+                    ->booleanNode('allow_customers')->isRequired()->defaultValue(false)->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
     }
 }

--- a/src/DependencyInjection/MonsieurBizSyliusNoCommerceExtension.php
+++ b/src/DependencyInjection/MonsieurBizSyliusNoCommerceExtension.php
@@ -26,7 +26,10 @@ final class MonsieurBizSyliusNoCommerceExtension extends Extension
     public function load(array $config, ContainerBuilder $container): void
     {
         $configuration = $this->getConfiguration([], $container);
-        $this->processConfiguration(/** @scrutinizer ignore-type */ $configuration, $config);
+        $config = $this->processConfiguration(/** @scrutinizer ignore-type */ $configuration, $config);
+        foreach ($config as $name => $value) {
+            $container->setParameter($this->getAlias() . '.' . $name, $value);
+        }
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
     }

--- a/src/Kernel/SyliusNoCommerceKernelTrait.php
+++ b/src/Kernel/SyliusNoCommerceKernelTrait.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusNoCommercePlugin\Kernel;
 
+use MonsieurBiz\SyliusNoCommercePlugin\Model\Config;
+use MonsieurBiz\SyliusNoCommercePlugin\Model\ConfigInterface;
 use MonsieurBiz\SyliusNoCommercePlugin\Routing\RouteCollectionBuilder;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -29,9 +31,21 @@ trait SyliusNoCommerceKernelTrait
      */
     public function loadRoutes(LoaderInterface $loader)
     {
-        $routes = new RouteCollectionBuilder($loader);
+        $routes = new RouteCollectionBuilder($this->getConfig(), $loader);
         $this->configureRoutes($routes);
 
         return $routes->build();
+    }
+
+    /**
+     * Create a NoCommerce Config object.
+     *
+     * @return ConfigInterface
+     */
+    private function getConfig(): ConfigInterface
+    {
+        return new Config(
+            (array) $this->container->getParameter('monsieurbiz_sylius_nocommerce.config') ?? []
+        );
     }
 }

--- a/src/Menu/AdminMenuListener.php
+++ b/src/Menu/AdminMenuListener.php
@@ -13,10 +13,18 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusNoCommercePlugin\Menu;
 
+use MonsieurBiz\SyliusNoCommercePlugin\Model\ConfigInterface;
 use Sylius\Bundle\UiBundle\Menu\Event\MenuBuilderEvent;
 
 final class AdminMenuListener
 {
+    private ConfigInterface $config;
+
+    public function __construct(ConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
     public function __invoke(MenuBuilderEvent $event): void
     {
         $menu = $event->getMenu();
@@ -24,7 +32,10 @@ final class AdminMenuListener
         $menu->removeChild('sales');
         $menu->removeChild('catalog');
         $menu->removeChild('marketing');
-        $menu->removeChild('customers');
+
+        if (!$this->config->getAllowCustomers()) {
+            $menu->removeChild('customers');
+        }
 
         if (null !== $configuration = $menu->getChild('configuration')) {
             $configuration->removeChild('currencies');

--- a/src/Menu/AdminMenuListener.php
+++ b/src/Menu/AdminMenuListener.php
@@ -33,7 +33,7 @@ final class AdminMenuListener
         $menu->removeChild('catalog');
         $menu->removeChild('marketing');
 
-        if (!$this->config->getAllowCustomers()) {
+        if (!$this->config->areCustomersAllowed()) {
             $menu->removeChild('customers');
         }
 

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -15,7 +15,7 @@ namespace MonsieurBiz\SyliusNoCommercePlugin\Model;
 
 final class Config implements ConfigInterface
 {
-    private $config = [];
+    private array $config = [];
 
     public function __construct(array $config)
     {

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' No Commerce plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusNoCommercePlugin\Model;
+
+final class Config implements ConfigInterface
+{
+    private $config = [];
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getAllowCustomers(): bool
+    {
+        return (bool) $this->config['allow_customers'] ?: false;
+    }
+}

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -22,7 +22,7 @@ final class Config implements ConfigInterface
         $this->config = $config;
     }
 
-    public function getAllowCustomers(): bool
+    public function areCustomersAllowed(): bool
     {
         return (bool) $this->config['allow_customers'] ?: false;
     }

--- a/src/Model/ConfigInterface.php
+++ b/src/Model/ConfigInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' No Commerce plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusNoCommercePlugin\Model;
+
+interface ConfigInterface
+{
+    /**
+     * Return true if customers are allowed on the website.
+     *
+     * @return bool
+     */
+    public function getAllowCustomers(): bool;
+}

--- a/src/Model/ConfigInterface.php
+++ b/src/Model/ConfigInterface.php
@@ -20,5 +20,5 @@ interface ConfigInterface
      *
      * @return bool
      */
-    public function getAllowCustomers(): bool;
+    public function areCustomersAllowed(): bool;
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -26,3 +26,7 @@ services:
     MonsieurBiz\SyliusNoCommercePlugin\Menu\ShopAccountMenuListener:
         tags:
             - { name: kernel.event_listener, event: sylius.menu.shop.account, priority: -10000 }
+
+    MonsieurBiz\SyliusNoCommercePlugin\Model\Config:
+        arguments:
+            $config: '%monsieurbiz_sylius_nocommerce.config%'

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -7,6 +7,9 @@ services:
         autoconfigure: true
         public: false
 
+    MonsieurBiz\SyliusNoCommercePlugin\:
+        resource: '../../*'
+
     MonsieurBiz\SyliusNoCommercePlugin\Form\Extension\:
         resource: '../../Form/Extension'
         tags:

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -7,9 +7,6 @@ services:
         autoconfigure: true
         public: false
 
-    MonsieurBiz\SyliusNoCommercePlugin\:
-        resource: '../../*'
-
     MonsieurBiz\SyliusNoCommercePlugin\Form\Extension\:
         resource: '../../Form/Extension'
         tags:
@@ -27,6 +24,7 @@ services:
         tags:
             - { name: kernel.event_listener, event: sylius.menu.shop.account, priority: -10000 }
 
+    MonsieurBiz\SyliusNoCommercePlugin\Model\ConfigInterface: '@MonsieurBiz\SyliusNoCommercePlugin\Model\Config'
     MonsieurBiz\SyliusNoCommercePlugin\Model\Config:
         arguments:
-            $config: '%monsieurbiz_sylius_nocommerce.config%'
+            - '%monsieurbiz_sylius_nocommerce.config%'

--- a/src/Routing/RouteCollectionBuilder.php
+++ b/src/Routing/RouteCollectionBuilder.php
@@ -13,149 +13,192 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusNoCommercePlugin\Routing;
 
+use MonsieurBiz\SyliusNoCommercePlugin\Model\ConfigInterface;
 use Symfony\Component\Config\Exception\LoaderLoadException;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\ResourceInterface;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouteCollectionBuilder as BaseRouteCollectionBuilder;
 
 class RouteCollectionBuilder extends BaseRouteCollectionBuilder
 {
     private ?LoaderInterface $loader;
+    private ConfigInterface $config;
     private array $resources = [];
 
     private array $routesToRemove = [
         // Customers & Account & Users
-        'sylius_admin_partial_customer',
-        'sylius_admin_customer',
-        'api_customer',
-        'sylius_shop_log',
-        'sylius_shop_register',
-        'sylius_shop_request_password_reset_token',
-        'sylius_shop_password_reset',
-        'sylius_shop_user_request_verification_token',
-        'sylius_shop_user_verification',
-        'sylius_shop_account',
-        'api_register_shop_users_post_collection',
-        'sylius_api_shop_authentication_token',
-        'sylius_shop_ajax_user_check_action',
+        'customer' => [
+            'sylius_admin_partial_customer',
+            'sylius_admin_customer',
+            'api_customer',
+            'sylius_shop_log',
+            'sylius_shop_register',
+            'sylius_shop_request_password_reset_token',
+            'sylius_shop_password_reset',
+            'sylius_shop_user_request_verification_token',
+            'sylius_shop_user_verification',
+            'sylius_shop_account',
+            'api_register_shop_users_post_collection',
+            'sylius_api_shop_authentication_token',
+            'sylius_shop_ajax_user_check_action',
+        ],
 
         // Products
-        'sylius_admin_product',
-        'sylius_admin_api_product',
-        'sylius_admin_ajax_product',
-        'sylius_shop_partial_product',
-        'sylius_shop_product',
-        'sylius_admin_partial_product',
-        'sylius_admin_ajax_generate_product_slug',
-        'api_product',
+        'product' => [
+            'sylius_admin_product',
+            'sylius_admin_api_product',
+            'sylius_admin_ajax_product',
+            'sylius_shop_partial_product',
+            'sylius_shop_product',
+            'sylius_admin_partial_product',
+            'sylius_admin_ajax_generate_product_slug',
+            'api_product',
+        ],
 
         // Taxons
-        'sylius_admin_partial_taxon',
-        'sylius_admin_ajax_taxon',
-        'sylius_admin_taxon',
-        'sylius_admin_api_taxon',
-        'sylius_shop_partial_taxon',
-        'sylius_admin_ajax_generate_taxon_slug',
-        'sylius_shop_partial_channel_menu_taxon_index',
-        'api_taxon',
+        'taxon' => [
+            'sylius_admin_partial_taxon',
+            'sylius_admin_ajax_taxon',
+            'sylius_admin_taxon',
+            'sylius_admin_api_taxon',
+            'sylius_shop_partial_taxon',
+            'sylius_admin_ajax_generate_taxon_slug',
+            'sylius_shop_partial_channel_menu_taxon_index',
+            'api_taxon',
+        ],
 
         // Checkout
-        'sylius_admin_api_checkout',
-        'sylius_shop_checkout',
-        'sylius_shop_register_after_checkout',
+        'checkout' => [
+            'sylius_admin_api_checkout',
+            'sylius_shop_checkout',
+            'sylius_shop_register_after_checkout',
+        ],
 
         // Addresses
-        'sylius_shop_account_address',
-        'sylius_admin_partial_address',
+        'address' => [
+            'sylius_shop_account_address',
+            'sylius_admin_partial_address',
+        ],
 
-        // orders
-        'sylius_admin_order',
-        'sylius_admin_api_order',
-        'sylius_shop_account_order',
-        'sylius_shop_order',
-        'sylius_admin_partial_order',
-        'sylius_admin_customer_order',
-        'sylius_admin_api_customer_order',
-        'api_order',
+        // Orders
+        'order' => [
+            'sylius_admin_order',
+            'sylius_admin_api_order',
+            'sylius_shop_account_order',
+            'sylius_shop_order',
+            'sylius_admin_partial_order',
+            'sylius_admin_customer_order',
+            'sylius_admin_api_customer_order',
+            'api_order',
+        ],
 
         // Adjustments
-        'sylius_admin_api_adjustment',
-        'sylius_shop_ajax_render_province_form',
-        'api_adjustment',
+        'adjustment' => [
+            'sylius_admin_api_adjustment',
+            'sylius_shop_ajax_render_province_form',
+            'api_adjustment',
+        ],
 
         // Promotions
-        'sylius_admin_partial_promotion',
-        'sylius_admin_promotion',
-        'sylius_admin_api_promotion',
-        'api_promo',
+        'promotion' => [
+            'sylius_admin_partial_promotion',
+            'sylius_admin_promotion',
+            'sylius_admin_api_promotion',
+            'api_promo',
+        ],
 
         // Shipping and Shipments
-        'sylius_admin_partial_shipment',
-        'sylius_admin_ship',
-        'sylius_admin_api_ship',
-        'api_ship',
+        'shipment' => [
+            'sylius_admin_partial_shipment',
+            'sylius_admin_ship',
+            'sylius_admin_api_ship',
+            'api_ship',
+        ],
 
         // Inventory
-        'sylius_admin_inventory',
+        'inventory' => [
+            'sylius_admin_inventory',
+        ],
 
         // Attributes
-        'sylius_admin_get_attribute_types',
-        'sylius_admin_get_product_attributes',
-        'sylius_admin_render_attribute_forms',
+        'attribute' => [
+            'sylius_admin_get_attribute_types',
+            'sylius_admin_get_product_attributes',
+            'sylius_admin_render_attribute_forms',
+        ],
 
         // Payments
-        'sylius_admin_payment',
-        'sylius_admin_get_payment',
-        'payum_',
-        'sylius_admin_api_payment',
-        'api_pay',
+        'payment' => [
+            'sylius_admin_payment',
+            'sylius_admin_get_payment',
+            'payum_',
+            'sylius_admin_api_payment',
+            'api_pay',
+        ],
 
         // Taxes
-        'sylius_admin_tax_',
-        'sylius_admin_api_tax_',
-        'api_tax',
+        'tax' => [
+            'sylius_admin_tax_',
+            'sylius_admin_api_tax_',
+            'api_tax',
+        ],
 
         // Currencies
-        'sylius_admin_currency',
-        'sylius_admin_api_currency',
-        'sylius_shop_switch_currency',
-        'api_currencies',
+        'currency' => [
+            'sylius_admin_currency',
+            'sylius_admin_api_currency',
+            'sylius_shop_switch_currency',
+            'api_currencies',
+        ],
 
         // Exchange rates
-        'sylius_admin_exchange',
-        'sylius_admin_api_exchange',
-        'api_exchange',
+        'exchange' => [
+            'sylius_admin_exchange',
+            'sylius_admin_api_exchange',
+            'api_exchange',
+        ],
 
         // Zones
-        'sylius_admin_zone',
-        'sylius_admin_api_zone',
-        'api_zone',
+        'zone' => [
+            'sylius_admin_zone',
+            'sylius_admin_api_zone',
+            'api_zone',
+        ],
 
         // Countries
-        'sylius_admin_country',
-        'sylius_admin_api_country',
-        'api_countries',
+        'country' => [
+            'sylius_admin_country',
+            'sylius_admin_api_country',
+            'api_countries',
+        ],
 
         // Provinces
-        'sylius_admin_api_province',
-        'sylius_admin_ajax_render_province_form',
-        'api_province',
+        'province' => [
+            'sylius_admin_api_province',
+            'sylius_admin_ajax_render_province_form',
+            'api_province',
+        ],
 
         // Carts
-        'sylius_admin_api_cart',
-        'sylius_shop_ajax_cart',
-        'sylius_shop_partial_cart',
-        'sylius_shop_cart',
-        'api_cart',
+        'cart' => [
+            'sylius_admin_api_cart',
+            'sylius_shop_ajax_cart',
+            'sylius_shop_partial_cart',
+            'sylius_shop_cart',
+            'api_cart',
+        ],
 
         // Dashboard
-        'sylius_admin_dashboard_statistics',
+        'dashboard' => [
+            'sylius_admin_dashboard_statistics',
+        ],
 
         // Others
-        'api_shop_billing',
-        'api_channels_shop',
+        'other' => [
+            'api_shop_billing',
+            'api_channels_shop',
+        ],
     ];
 
     /**
@@ -163,9 +206,10 @@ class RouteCollectionBuilder extends BaseRouteCollectionBuilder
      *
      * @param LoaderInterface|null $loader
      */
-    public function __construct(LoaderInterface $loader = null)
+    public function __construct(ConfigInterface $config, LoaderInterface $loader = null)
     {
         parent::__construct($loader);
+        $this->config = $config;
         $this->loader = $loader;
     }
 
@@ -185,10 +229,11 @@ class RouteCollectionBuilder extends BaseRouteCollectionBuilder
 
         // create a builder from the RouteCollection
         $builder = $this->createBuilder();
+        $routesToRemove = $this->getRoutesToRemove();
 
         foreach ($collections as $collection) {
             foreach ($collection->all() as $name => $route) {
-                foreach ($this->routesToRemove as $routeToRemove) {
+                foreach ($routesToRemove as $routeToRemove) {
                     if (false !== strpos($name, $routeToRemove)) {
                         $route->setCondition('1 == 0');
                     }
@@ -214,7 +259,7 @@ class RouteCollectionBuilder extends BaseRouteCollectionBuilder
      */
     public function createBuilder()
     {
-        return new self($this->loader);
+        return new self($this->config, $this->loader);
     }
 
     /**
@@ -259,5 +304,27 @@ class RouteCollectionBuilder extends BaseRouteCollectionBuilder
         $collections = $loader->load($resource, $type);
 
         return \is_array($collections) ? $collections : [$collections];
+    }
+
+    /**
+     * Retrieve all routes to remove depending on config.
+     *
+     * @return array
+     */
+    private function getRoutesToRemove(): array
+    {
+        $routesToRemove = [];
+
+        if ($this->config->getAllowCustomers()) {
+            unset($this->routesToRemove['customer']);
+        }
+
+        foreach ($this->routesToRemove as $type => $routes) {
+            foreach ($routes as $route) {
+                $routesToRemove[] = $route;
+            }
+        }
+
+        return $routesToRemove;
     }
 }

--- a/src/Routing/RouteCollectionBuilder.php
+++ b/src/Routing/RouteCollectionBuilder.php
@@ -319,7 +319,7 @@ class RouteCollectionBuilder extends BaseRouteCollectionBuilder
             unset($this->routesToRemove['customer']);
         }
 
-        foreach ($this->routesToRemove as $type => $routes) {
+        foreach ($this->routesToRemove as $routes) {
             $routesToRemove = array_merge($routesToRemove, $routes);
         }
 

--- a/src/Routing/RouteCollectionBuilder.php
+++ b/src/Routing/RouteCollectionBuilder.php
@@ -315,7 +315,7 @@ class RouteCollectionBuilder extends BaseRouteCollectionBuilder
     {
         $routesToRemove = [];
 
-        if ($this->config->getAllowCustomers()) {
+        if ($this->config->areCustomersAllowed()) {
             unset($this->routesToRemove['customer']);
         }
 

--- a/src/Routing/RouteCollectionBuilder.php
+++ b/src/Routing/RouteCollectionBuilder.php
@@ -320,9 +320,7 @@ class RouteCollectionBuilder extends BaseRouteCollectionBuilder
         }
 
         foreach ($this->routesToRemove as $type => $routes) {
-            foreach ($routes as $route) {
-                $routesToRemove[] = $route;
-            }
+            $routesToRemove = array_merge($routesToRemove, $routes);
         }
 
         return $routesToRemove;

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,10 @@
 {
+    "aeon-php/calendar": {
+        "version": "0.16.1"
+    },
+    "alcohol/iso4217": {
+        "version": "3.1.5"
+    },
     "amphp/amp": {
         "version": "v2.5.0"
     },
@@ -197,6 +203,9 @@
             ".php_cs.dist"
         ]
     },
+    "friendsofphp/proxy-manager-lts": {
+        "version": "v1.0.3"
+    },
     "friendsofsymfony/oauth-server-bundle": {
         "version": "1.6.2"
     },
@@ -295,6 +304,9 @@
     },
     "lchrusciel/api-test-case": {
         "version": "v5.0.0"
+    },
+    "lcobucci/clock": {
+        "version": "2.0.0"
     },
     "lcobucci/jwt": {
         "version": "3.3.3"

--- a/tests/Application/config/bootstrap.php
+++ b/tests/Application/config/bootstrap.php
@@ -29,4 +29,4 @@ if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], \FILTER_VALIDATE_BOOLEAN) ? '1' : '0';


### PR DESCRIPTION
With this pull request you can easily enabled customers (users) on the website.

## Flag to true

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/11380627/111337210-3053e700-8676-11eb-8ca3-b38ac5e17689.png">

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/11380627/111337236-377af500-8676-11eb-88a2-2a76b531a64e.png">

## Flag to false 

<img width="1676" alt="image" src="https://user-images.githubusercontent.com/11380627/111337131-1e724400-8676-11eb-8866-7001d482b94b.png">

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/11380627/111337287-419cf380-8676-11eb-921e-a2a927cb5268.png">

## Customer view

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/11380627/111591565-e9760680-87c7-11eb-9347-69e7e47368a0.png">

## Customer Edit

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/11380627/111591594-f266d800-87c7-11eb-9065-617f75934938.png">
