### PR TITLE
Remove scrutinizer's badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 
 [![No Commerce Plugin license](https://img.shields.io/github/license/monsieurbiz/SyliusNoCommercePlugin)](https://github.com/monsieurbiz/SyliusNoCommercePlugin/blob/master/LICENSE.txt)
 ![Tests](https://img.shields.io/github/workflow/status/monsieurbiz/SyliusNoCommercePlugin/Tests/master?label=tests&logo=github)
-[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/quality/g/monsieurbiz/SyliusNoCommercePlugin/master?logo=scrutinizer)](https://scrutinizer-ci.com/g/monsieurbiz/SyliusNoCommercePlugin/?branch=master)
-
 
 This plugin disables the e-commerce parts of Sylius.  
 Basically it disables the routes and updates the admin and frontend templates.


### PR DESCRIPTION
The repo on Scrutinizer has been removed.

We don't use it anymore at @MonsieurBiz.

