### PR TITLE
 Allow routes to be ignored in the disable firewall listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ monsieurbiz_sylius_nocommerce:
 
 You can allow different sections by changing the parameters to `true`.
 
+## Ignore routes
+
+By default, the disable firewall listener will ignore the following routes for the developer toolbar.
+
+You can ignore additional routes, such as the preview route for error pages, by adding them to the `config/packages/monsieurbiz_sylius_nocommerce_plugin.yaml` file:
+
+```yaml
+parameters:
+    monsieurbiz_sylius_nocommerce.disable_firewall.ignored_routes:
+        - "_preview_error"
+```
+
 ## Contributing
 
 You can open an issue or a Pull Request if you want! 😘  

--- a/src/EventListener/DisableFirewallListener.php
+++ b/src/EventListener/DisableFirewallListener.php
@@ -34,16 +34,20 @@ final class DisableFirewallListener
 
     private FeaturesProviderInterface $featuresProvider;
 
+    private array $ignoredRoutes;
+
     public function __construct(
         FirewallMap $firewallContext,
         SettingsInterface $nocommerceSettings,
         ChannelContextInterface $channelContext,
-        FeaturesProviderInterface $featuresProvider
+        FeaturesProviderInterface $featuresProvider,
+        array $ignoredRoutes = []
     ) {
         $this->firewallContext = $firewallContext;
         $this->nocommerceSettings = $nocommerceSettings;
         $this->channelContext = $channelContext;
         $this->featuresProvider = $featuresProvider;
+        $this->ignoredRoutes = $ignoredRoutes;
     }
 
     /**
@@ -73,9 +77,10 @@ final class DisableFirewallListener
 
     private function canCheckRoute(RequestEvent $event): bool
     {
-        // allow profiler routes
+        $ignoredRoutes = array_merge(self::PROFILER_ROUTES, $this->ignoredRoutes);
+
         return $event->isMainRequest()
-            && !\in_array($event->getRequest()->attributes->get('_route'), self::PROFILER_ROUTES, true);
+            && !\in_array($event->getRequest()->attributes->get('_route'), $ignoredRoutes, true);
     }
 
     private function getFirewallContextName(Request $request): string

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -1,5 +1,6 @@
 parameters:
     sylius.form.type.channel.validation_groups: [monsieurbiz_nocommerce]
+    monsieurbiz_sylius_nocommerce.disable_firewall.ignored_routes: []
 
 services:
     _defaults:
@@ -22,12 +23,14 @@ services:
     MonsieurBiz\SyliusNoCommercePlugin\Menu\AdminCustomerShowMenuListener:
         tags:
             - { name: kernel.event_listener, event: sylius.menu.admin.customer.show, priority: -10000 }
-    
+
     MonsieurBiz\SyliusNoCommercePlugin\Menu\ShopAccountMenuListener:
         tags:
             - { name: kernel.event_listener, event: sylius.menu.shop.account, priority: -10000 }
-                
+
     MonsieurBiz\SyliusNoCommercePlugin\EventListener\DisableFirewallListener:
+        arguments:
+            $ignoredRoutes: '%monsieurbiz_sylius_nocommerce.disable_firewall.ignored_routes%'
         tags:
             - { name: kernel.event_listener, event: kernel.request, priority: -10000 }
 
@@ -54,17 +57,17 @@ services:
         arguments:
             - '@MonsieurBiz\SyliusNoCommercePlugin\Context\NoCurrencyContext.inner'
             - '@monsieurbiz.no_commerce.provider.features_provider'
-    
+
     MonsieurBiz\SyliusNoCommercePlugin\Registry\TemplateBlockRegistryDecorator:
         decorates: 'Sylius\Bundle\UiBundle\Registry\TemplateBlockRegistryInterface'
         arguments:
             $templateBlockRegistry: '@MonsieurBiz\SyliusNoCommercePlugin\Registry\TemplateBlockRegistryDecorator.inner'
             $featuresProvider: '@monsieurbiz.no_commerce.provider.features_provider'
 
-    monsieurbiz.no_commerce.provider.features_provider: 
+    monsieurbiz.no_commerce.provider.features_provider:
         class: 'MonsieurBiz\SyliusNoCommercePlugin\Provider\FeaturesProvider'
         public: true
-        
+
     # Routing Context
     MonsieurBiz\SyliusNoCommercePlugin\Routing\NoCommerceRequestContext:
         decorates: router.request_context


### PR DESCRIPTION
Example to allow error preview routes, add these lines in `config/packages/monsieurbiz_sylius_nocommerce_plugin.yaml`:

```yaml
parameters:
    monsieurbiz_sylius_nocommerce.disable_firewall.ignored_routes:
        - "_preview_error"
```