### PR TITLE
Allow to enabled some routes for admin through configuration in BO

### DIFF
--- a/src/Form/Type/Settings/NoCommerceType.php
+++ b/src/Form/Type/Settings/NoCommerceType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace MonsieurBiz\SyliusNoCommercePlugin\Form\Type\Settings;
 
 use MonsieurBiz\SyliusNoCommercePlugin\Firewall\RegistryInterface;
+use MonsieurBiz\SyliusNoCommercePlugin\Provider\FeaturesProvider;
 use MonsieurBiz\SyliusSettingsPlugin\Form\AbstractSettingsType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -59,6 +60,21 @@ class NoCommerceType extends AbstractSettingsType
             'required' => false,
             'multiple' => true,
             'choices' => $choices,
+        ]);
+        $this->addWithDefaultCheckbox($builder, 're_enabled_admin_routes', ChoiceType::class, [
+            'label' => 'monsieurbiz.nocommerce.ui.form.field.re_enabled_admin_routes.label',
+            'required' => false,
+            'multiple' => true,
+            'choices' => [
+                'sylius.ui.countries' => FeaturesProvider::COUNTRIES_KEY,
+                'sylius.ui.currencies' => FeaturesProvider::CURRENCIES_KEY,
+                'sylius.ui.inventory' => FeaturesProvider::INVENTORY_KEY,
+                'sylius.ui.payment' => FeaturesProvider::PAYMENT_KEY,
+                'sylius.menu.admin.main.catalog.header' => FeaturesProvider::CATALOG_KEY,
+                'sylius.ui.shipping' => FeaturesProvider::SHIPPING_KEY,
+                'sylius.ui.tax' => FeaturesProvider::TAX_KEY,
+                'sylius.ui.zones' => FeaturesProvider::ZONES_KEY,
+            ],
         ]);
     }
 }

--- a/src/Kernel/SyliusNoCommerceKernelTrait.php
+++ b/src/Kernel/SyliusNoCommerceKernelTrait.php
@@ -216,7 +216,7 @@ trait SyliusNoCommerceKernelTrait
         foreach ($collection as $name => $route) {
             foreach ($routesToRemove as $routeToRemove) {
                 if (false !== strpos($name, $routeToRemove)) {
-                    $route->setCondition('not context.checkNoCommerce()');
+                    $route->setCondition('not context.checkNoCommerce(params)');
                 }
             }
         }

--- a/src/Provider/FeaturesProvider.php
+++ b/src/Provider/FeaturesProvider.php
@@ -20,6 +20,60 @@ use Sylius\Component\Core\Model\ChannelInterface;
 
 final class FeaturesProvider implements FeaturesProviderInterface
 {
+    public const COUNTRIES_KEY = 'countries';
+
+    public const CURRENCIES_KEY = 'currencies';
+
+    public const INVENTORY_KEY = 'inventory';
+
+    public const PAYMENT_KEY = 'payment';
+
+    public const CATALOG_KEY = 'catalog';
+
+    public const SHIPPING_KEY = 'shipping';
+
+    public const TAX_KEY = 'tax';
+
+    public const ZONES_KEY = 'zones';
+
+    public const ADMIN_ROUTES_THAT_CAN_BE_RE_ENABLED = [
+        self::COUNTRIES_KEY => [
+            'sylius_admin_country',
+            'sylius_admin_ajax_render_province_form',
+        ],
+        self::CURRENCIES_KEY => [
+            'sylius_admin_currency',
+        ],
+        self::INVENTORY_KEY => [
+            'sylius_admin_inventory',
+        ],
+        self::PAYMENT_KEY => [
+            'sylius_admin_payment_method',
+        ],
+        self::CATALOG_KEY => [
+            'sylius_admin_get_attribute_types',
+            'sylius_admin_get_product_attributes',
+            'sylius_admin_render_attribute_forms',
+            'sylius_admin_product',
+            'sylius_admin_ajax_product',
+            'sylius_admin_partial_product',
+            'sylius_admin_ajax_generate_product_slug',
+            'sylius_admin_partial_taxon',
+            'sylius_admin_ajax_taxon',
+            'sylius_admin_taxon',
+            'sylius_admin_ajax_generate_taxon_slug',
+        ],
+        self::SHIPPING_KEY => [
+            'sylius_admin_shipping',
+        ],
+        self::TAX_KEY => [
+            'sylius_admin_tax_',
+        ],
+        self::ZONES_KEY => [
+            'sylius_admin_zone',
+        ],
+    ];
+
     private ChannelContextInterface $channelContext;
 
     private SettingsInterface $nocommerceSettings;
@@ -38,7 +92,7 @@ final class FeaturesProvider implements FeaturesProviderInterface
             if (null === $channel) {
                 $channel = $this->channelContext->getChannel();
             }
-            // In case we are getting a channel that does not exists yet we return null to have the channel set properly
+            // In case we are getting a channel that does not exist yet, we return null to have the channel set properly
             if (null === $channel->getId()) {
                 return true;
             }
@@ -47,5 +101,38 @@ final class FeaturesProvider implements FeaturesProviderInterface
         }
 
         return (bool) $this->nocommerceSettings->getCurrentValue($channel, null, 'enabled');
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function isRouteForcedEnabled(array $params = []): bool
+    {
+        if (!isset($params['_route'])) {
+            return false;
+        }
+
+        $route = $params['_route'];
+        $channel = $this->channelContext->getChannel();
+        /** @var ?array $reEnabledAdminRoutes */
+        $reEnabledAdminRoutes = $this->nocommerceSettings->getCurrentValue($channel, null, 're_enabled_admin_routes');
+
+        if (empty($reEnabledAdminRoutes)) {
+            return false;
+        }
+
+        // We are checking if we should re-enable the route
+        foreach ($reEnabledAdminRoutes as $reEnabledAdminSection) {
+            if (!isset(self::ADMIN_ROUTES_THAT_CAN_BE_RE_ENABLED[$reEnabledAdminSection])) {
+                continue;
+            }
+            foreach (self::ADMIN_ROUTES_THAT_CAN_BE_RE_ENABLED[$reEnabledAdminSection] as $reEnabledAdminRoute) {
+                if (false !== strpos($route, $reEnabledAdminRoute)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Provider/FeaturesProviderInterface.php
+++ b/src/Provider/FeaturesProviderInterface.php
@@ -18,4 +18,6 @@ use Sylius\Component\Core\Model\ChannelInterface;
 interface FeaturesProviderInterface
 {
     public function isNoCommerceEnabledForChannel(?ChannelInterface $channel = null): bool;
+
+    public function isRouteForcedEnabled(array $params = []): bool;
 }

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -7,3 +7,5 @@ monsieurbiz:
                         label: Firewalls to be disabled
                     enabled:
                         label: Enabled
+                    re_enabled_admin_routes: 
+                        label: Admin routes to re-enable

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -7,3 +7,5 @@ monsieurbiz:
                         label: Firewalls à désactiver
                     enabled:
                         label: Activer
+                    re_enabled_admin_routes: 
+                        label: Routes à réactiver pour l'admin

--- a/src/Routing/NoCommerceRequestContext.php
+++ b/src/Routing/NoCommerceRequestContext.php
@@ -41,9 +41,9 @@ final class NoCommerceRequestContext extends BaseRequestContext
         $this->featuresProvider = $featuresProvider;
     }
 
-    public function checkNoCommerce(): bool
+    public function checkNoCommerce(array $params = []): bool
     {
-        return $this->featuresProvider->isNoCommerceEnabledForChannel();
+        return $this->featuresProvider->isNoCommerceEnabledForChannel() && !$this->featuresProvider->isRouteForcedEnabled($params);
     }
 
     /**


### PR DESCRIPTION
Sometimes the plugin NoCommerce is just a step before a standard commerce shop. 
This PR is here to allow some routes in admin only in order to prepare a shop towards the deactivation of the NoCommercePlugin. Meaning, you can enable some routes to add your products, taxons, shipping methods, payment methods, etc


https://github.com/user-attachments/assets/6660be99-a4ea-4dd4-8a01-31369699badc

