### PR TITLE
Route to enable are now matching with the full array routes

### DIFF
--- a/docker-compose.yaml.dist
+++ b/docker-compose.yaml.dist
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
     database:
         image: mysql:8.0

--- a/src/Form/Type/Settings/NoCommerceType.php
+++ b/src/Form/Type/Settings/NoCommerceType.php
@@ -68,7 +68,7 @@ class NoCommerceType extends AbstractSettingsType
                 'label' => 'monsieurbiz.nocommerce.ui.form.field.routes_to_enable.label',
                 'required' => false,
                 'multiple' => true,
-                'expanded' => true,
+                'expanded' => false,
                 'choices' => $this->getEnabledRouteChoices(),
             ]);
         }
@@ -77,10 +77,14 @@ class NoCommerceType extends AbstractSettingsType
     private function getEnabledRouteChoices(): array
     {
         $allRoutes = ConfigInterface::ROUTES_BY_GROUP;
+        $choices = [];
 
-        return array_combine(
-            array_map(static fn ($key) => 'monsieurbiz.nocommerce.ui.' . $key, array_keys($allRoutes)),
-            array_keys($allRoutes)
-        );
+        foreach ($allRoutes as $group => $routes) {
+            foreach ($routes as $route) {
+                $choices[$group][$route] = $route;
+            }
+        }
+
+        return $choices;
     }
 }

--- a/src/Form/Type/Settings/NoCommerceType.php
+++ b/src/Form/Type/Settings/NoCommerceType.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace MonsieurBiz\SyliusNoCommercePlugin\Form\Type\Settings;
 
 use MonsieurBiz\SyliusNoCommercePlugin\Firewall\RegistryInterface;
-use MonsieurBiz\SyliusNoCommercePlugin\Provider\FeaturesProvider;
+use MonsieurBiz\SyliusNoCommercePlugin\Model\ConfigInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Form\AbstractSettingsType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -35,6 +35,7 @@ class NoCommerceType extends AbstractSettingsType
 
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -61,20 +62,25 @@ class NoCommerceType extends AbstractSettingsType
             'multiple' => true,
             'choices' => $choices,
         ]);
-        $this->addWithDefaultCheckbox($builder, 're_enabled_admin_routes', ChoiceType::class, [
-            'label' => 'monsieurbiz.nocommerce.ui.form.field.re_enabled_admin_routes.label',
-            'required' => false,
-            'multiple' => true,
-            'choices' => [
-                'sylius.ui.countries' => FeaturesProvider::COUNTRIES_KEY,
-                'sylius.ui.currencies' => FeaturesProvider::CURRENCIES_KEY,
-                'sylius.ui.inventory' => FeaturesProvider::INVENTORY_KEY,
-                'sylius.ui.payment' => FeaturesProvider::PAYMENT_KEY,
-                'sylius.menu.admin.main.catalog.header' => FeaturesProvider::CATALOG_KEY,
-                'sylius.ui.shipping' => FeaturesProvider::SHIPPING_KEY,
-                'sylius.ui.tax' => FeaturesProvider::TAX_KEY,
-                'sylius.ui.zones' => FeaturesProvider::ZONES_KEY,
-            ],
-        ]);
+
+        if ($this->isDefaultForm($builder)) {
+            $this->addWithDefaultCheckbox($builder, 'routes_to_enable', ChoiceType::class, [
+                'label' => 'monsieurbiz.nocommerce.ui.form.field.routes_to_enable.label',
+                'required' => false,
+                'multiple' => true,
+                'expanded' => true,
+                'choices' => $this->getEnabledRouteChoices(),
+            ]);
+        }
+    }
+
+    private function getEnabledRouteChoices(): array
+    {
+        $allRoutes = ConfigInterface::ROUTES_BY_GROUP;
+
+        return array_combine(
+            array_map(static fn ($key) => 'monsieurbiz.nocommerce.ui.' . $key, array_keys($allRoutes)),
+            array_keys($allRoutes)
+        );
     }
 }

--- a/src/Kernel/SyliusNoCommerceKernelTrait.php
+++ b/src/Kernel/SyliusNoCommerceKernelTrait.php
@@ -15,6 +15,7 @@ namespace MonsieurBiz\SyliusNoCommercePlugin\Kernel;
 
 use MonsieurBiz\SyliusNoCommercePlugin\Model\Config;
 use MonsieurBiz\SyliusNoCommercePlugin\Model\ConfigInterface;
+use MonsieurBiz\SyliusNoCommercePlugin\Provider\FeaturesProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Routing\RouteCollection;
@@ -24,186 +25,6 @@ trait SyliusNoCommerceKernelTrait
     use MicroKernelTrait {
         MicroKernelTrait::loadRoutes as parentLoadRoutes;
     }
-
-    private array $routesToRemove = [
-        // Customers & Account & Users
-        'customer' => [
-            'sylius_admin_partial_customer',
-            'sylius_admin_customer',
-            'api_customer',
-            'sylius_shop_log',
-            'sylius_shop_register',
-            'sylius_shop_request_password_reset_token',
-            'sylius_shop_password_reset',
-            'sylius_shop_user_request_verification_token',
-            'sylius_shop_user_verification',
-            'sylius_shop_account',
-            'api_register_shop_users_post_collection',
-            'sylius_api_shop_authentication_token',
-            'sylius_shop_ajax_user_check_action',
-        ],
-
-        // Products
-        'product' => [
-            'sylius_admin_product',
-            'sylius_admin_api_product',
-            'sylius_admin_ajax_product',
-            'sylius_shop_partial_product',
-            'sylius_shop_product',
-            'sylius_admin_partial_product',
-            'sylius_admin_ajax_generate_product_slug',
-            'api_product',
-        ],
-
-        // Taxons
-        'taxon' => [
-            'sylius_admin_partial_taxon',
-            'sylius_admin_ajax_taxon',
-            'sylius_admin_taxon',
-            'sylius_admin_api_taxon',
-            'sylius_shop_partial_taxon',
-            'sylius_admin_ajax_generate_taxon_slug',
-            'sylius_shop_partial_channel_menu_taxon_index',
-            'api_taxon',
-        ],
-
-        // Checkout
-        'checkout' => [
-            'sylius_admin_api_checkout',
-            'sylius_shop_checkout',
-            'sylius_shop_register_after_checkout',
-        ],
-
-        // Addresses
-        'address' => [
-            'sylius_shop_account_address',
-            'sylius_admin_partial_address',
-        ],
-
-        // Orders
-        'order' => [
-            'sylius_admin_order',
-            'sylius_admin_api_order',
-            'sylius_shop_account_order',
-            'sylius_shop_order',
-            'sylius_admin_partial_order',
-            'sylius_admin_customer_order',
-            'sylius_admin_api_customer_order',
-            'api_order',
-        ],
-
-        // Adjustments
-        'adjustment' => [
-            'sylius_admin_api_adjustment',
-            'sylius_shop_ajax_render_province_form',
-            'api_adjustment',
-        ],
-
-        // Promotions
-        'promotion' => [
-            'sylius_admin_partial_promotion',
-            'sylius_admin_promotion',
-            'sylius_admin_api_promotion',
-            'api_promo',
-        ],
-
-        // Shipping and Shipments
-        'shipment' => [
-            'sylius_admin_partial_shipment',
-            'sylius_admin_ship',
-            'sylius_admin_api_ship',
-            'api_ship',
-        ],
-
-        // Inventory
-        'inventory' => [
-            'sylius_admin_inventory',
-        ],
-
-        // Attributes
-        'attribute' => [
-            'sylius_admin_get_attribute_types',
-            'sylius_admin_get_product_attributes',
-            'sylius_admin_render_attribute_forms',
-        ],
-
-        // Payments
-        'payment' => [
-            'sylius_admin_payment',
-            'sylius_admin_get_payment',
-            'payum_',
-            'sylius_admin_api_payment',
-            'api_pay',
-        ],
-
-        // PayPal
-        'paypal' => [
-            'sylius_paypal',
-        ],
-
-        // Taxes
-        'tax' => [
-            'sylius_admin_tax_',
-            'sylius_admin_api_tax_',
-            'api_tax',
-        ],
-
-        // Currencies
-        'currency' => [
-            'sylius_admin_currency',
-            'sylius_admin_api_currency',
-            'sylius_shop_switch_currency',
-            'api_currencies',
-        ],
-
-        // Exchange rates
-        'exchange' => [
-            'sylius_admin_exchange',
-            'sylius_admin_api_exchange',
-            'api_exchange',
-        ],
-
-        // Zones
-        'zone' => [
-            'sylius_admin_zone',
-            'sylius_admin_api_zone',
-            'api_zone',
-        ],
-
-        // Countries
-        'country' => [
-            'sylius_admin_country',
-            'sylius_admin_api_country',
-            'api_countries',
-        ],
-
-        // Provinces
-        'province' => [
-            'sylius_admin_api_province',
-            'sylius_admin_ajax_render_province_form',
-            'api_province',
-        ],
-
-        // Carts
-        'cart' => [
-            'sylius_admin_api_cart',
-            'sylius_shop_ajax_cart',
-            'sylius_shop_partial_cart',
-            'sylius_shop_cart',
-            'api_cart',
-        ],
-
-        // Dashboard
-        'dashboard' => [
-            'sylius_admin_dashboard_statistics',
-        ],
-
-        // Others
-        'other' => [
-            'api_shop_billing',
-            'api_channels_shop',
-        ],
-    ];
 
     /**
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -216,7 +37,7 @@ trait SyliusNoCommerceKernelTrait
         foreach ($collection as $name => $route) {
             foreach ($routesToRemove as $routeToRemove) {
                 if (false !== strpos($name, $routeToRemove)) {
-                    $route->setCondition('not context.checkNoCommerce(params)');
+                    $route->setCondition('not context.checkNoCommerce()');
                 }
             }
         }
@@ -239,21 +60,36 @@ trait SyliusNoCommerceKernelTrait
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    private function getRoutesToRemove(): array
+    public function getRoutesToRemove(): array
     {
         $config = $this->getConfig();
         $routesToRemove = [];
+        $this->routesToRemove = ConfigInterface::ROUTES_BY_GROUP;
 
+        /** @deprecated */
         if ($config->areCustomersAllowed()) {
             unset($this->routesToRemove['customer']);
         }
 
+        /** @deprecated */
         if ($config->areZonesAllowed()) {
             unset($this->routesToRemove['zone']);
         }
 
+        /** @deprecated */
         if ($config->areZonesAllowed() || $config->areCountriesAllowed()) {
             unset($this->routesToRemove['country']);
+        }
+
+        // Loop on settings to add routes
+        /** @var FeaturesProviderInterface $featuresProvider */
+        $featuresProvider = $this->container->get('monsieurbiz.no_commerce.provider.features_provider');
+        $routesToEnable = $featuresProvider->getRoutesToEnable();
+
+        foreach ($routesToEnable as $route) {
+            if (isset($this->routesToRemove[$route])) {
+                unset($this->routesToRemove[$route]);
+            }
         }
 
         foreach ($this->routesToRemove as $routes) {

--- a/src/Kernel/SyliusNoCommerceKernelTrait.php
+++ b/src/Kernel/SyliusNoCommerceKernelTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusNoCommercePlugin\Kernel;
 
+use Exception;
 use MonsieurBiz\SyliusNoCommercePlugin\Model\Config;
 use MonsieurBiz\SyliusNoCommercePlugin\Model\ConfigInterface;
 use MonsieurBiz\SyliusNoCommercePlugin\Provider\FeaturesProviderInterface;
@@ -84,7 +85,12 @@ trait SyliusNoCommerceKernelTrait
         // Loop on settings to add routes
         /** @var FeaturesProviderInterface $featuresProvider */
         $featuresProvider = $this->container->get('monsieurbiz.no_commerce.provider.features_provider');
-        $routesToEnable = $featuresProvider->getRoutesToEnable();
+
+        try {
+            $routesToEnable = $featuresProvider->getRoutesToEnable();
+        } catch (Exception $e) {
+            $routesToEnable = [];
+        }
 
         foreach ($routesToEnable as $route) {
             $this->enableRoute($route);

--- a/src/Kernel/SyliusNoCommerceKernelTrait.php
+++ b/src/Kernel/SyliusNoCommerceKernelTrait.php
@@ -87,9 +87,7 @@ trait SyliusNoCommerceKernelTrait
         $routesToEnable = $featuresProvider->getRoutesToEnable();
 
         foreach ($routesToEnable as $route) {
-            if (isset($this->routesToRemove[$route])) {
-                unset($this->routesToRemove[$route]);
-            }
+            $this->enableRoute($route);
         }
 
         foreach ($this->routesToRemove as $routes) {
@@ -97,5 +95,18 @@ trait SyliusNoCommerceKernelTrait
         }
 
         return $routesToRemove;
+    }
+
+    private function enableRoute(string $route): void
+    {
+        foreach ($this->routesToRemove as $group => $routes) {
+            if (false !== ($key = array_search($route, $routes, true))) {
+                unset($this->routesToRemove[$group][$key]);
+            }
+
+            if (empty($this->routesToRemove[$group])) {
+                unset($this->routesToRemove[$group]);
+            }
+        }
     }
 }

--- a/src/Model/ConfigInterface.php
+++ b/src/Model/ConfigInterface.php
@@ -16,11 +16,14 @@ namespace MonsieurBiz\SyliusNoCommercePlugin\Model;
 interface ConfigInterface
 {
     public const ROUTES_BY_GROUP = [
-        // Customers & Account & Users
-        'customer' => [
+        /**
+         * Customers & Account & Users.
+         */
+        'customer_admin' => [
             'sylius_admin_partial_customer',
             'sylius_admin_customer',
-            'api_customer',
+        ],
+        'customer_shop' => [
             'sylius_shop_log',
             'sylius_shop_register',
             'sylius_shop_request_password_reset_token',
@@ -28,169 +31,159 @@ interface ConfigInterface
             'sylius_shop_user_request_verification_token',
             'sylius_shop_user_verification',
             'sylius_shop_account',
-            'api_register_shop_users_post_collection',
-            'sylius_api_shop_authentication_token',
             'sylius_shop_ajax_user_check_action',
         ],
-
-        // Products
-        'product' => [
+        'customer_api' => [
+            'api_customer',
+            'api_register_shop_users_post_collection',
+            'sylius_api_shop_authentication_token',
+        ],
+        /**
+         * Catalog.
+         */
+        'catalog_admin' => [
             'sylius_admin_product',
-            'sylius_admin_api_product',
             'sylius_admin_ajax_product',
-            'sylius_shop_partial_product',
-            'sylius_shop_product',
             'sylius_admin_partial_product',
             'sylius_admin_ajax_generate_product_slug',
-            'api_product',
-        ],
-
-        // Taxons
-        'taxon' => [
             'sylius_admin_partial_taxon',
             'sylius_admin_ajax_taxon',
             'sylius_admin_taxon',
-            'sylius_admin_api_taxon',
-            'sylius_shop_partial_taxon',
             'sylius_admin_ajax_generate_taxon_slug',
-            'sylius_shop_partial_channel_menu_taxon_index',
-            'api_taxon',
-        ],
-
-        // Checkout
-        'checkout' => [
-            'sylius_admin_api_checkout',
-            'sylius_shop_checkout',
-            'sylius_shop_register_after_checkout',
-        ],
-
-        // Addresses
-        'address' => [
-            'sylius_shop_account_address',
-            'sylius_admin_partial_address',
-        ],
-
-        // Orders
-        'order' => [
-            'sylius_admin_order',
-            'sylius_admin_api_order',
-            'sylius_shop_account_order',
-            'sylius_shop_order',
-            'sylius_admin_partial_order',
-            'sylius_admin_customer_order',
-            'sylius_admin_api_customer_order',
-            'api_order',
-        ],
-
-        // Adjustments
-        'adjustment' => [
-            'sylius_admin_api_adjustment',
-            'sylius_shop_ajax_render_province_form',
-            'api_adjustment',
-        ],
-
-        // Promotions
-        'promotion' => [
-            'sylius_admin_partial_promotion',
-            'sylius_admin_promotion',
-            'sylius_admin_api_promotion',
-            'sylius_admin_catalog_promotion',
-            'api_promo',
-        ],
-
-        // Shipping and Shipments
-        'shipment' => [
-            'sylius_admin_partial_shipment',
-            'sylius_admin_ship',
-            'sylius_admin_api_ship',
-            'api_ship',
-        ],
-
-        // Inventory
-        'inventory' => [
-            'sylius_admin_inventory',
-        ],
-
-        // Attributes
-        'attribute' => [
             'sylius_admin_get_attribute_types',
             'sylius_admin_get_product_attributes',
             'sylius_admin_render_attribute_forms',
-        ],
-
-        // Payments
-        'payment' => [
-            'sylius_admin_payment',
-            'sylius_admin_get_payment',
-            'payum_',
-            'sylius_admin_api_payment',
-            'api_pay',
-        ],
-
-        // PayPal
-        'paypal' => [
-            'sylius_paypal',
-        ],
-
-        // Taxes
-        'tax' => [
+            'sylius_admin_inventory',
             'sylius_admin_tax_',
             'sylius_admin_api_tax_',
+        ],
+        'catalog_shop' => [
+            'sylius_shop_partial_product',
+            'sylius_shop_product',
+            'sylius_shop_partial_taxon',
+            'sylius_shop_partial_channel_menu_taxon_index',
+        ],
+        'catalog_api' => [
+            'sylius_admin_api_product',
+            'api_product',
+            'sylius_admin_api_taxon',
+            'api_taxon',
             'api_tax',
         ],
-
-        // Currencies
-        'currency' => [
+        /**
+         * Addresses.
+         */
+        'address_shop' => [
+            'sylius_shop_account_address',
+            'sylius_shop_ajax_render_province_form',
+        ],
+        /**
+         * Orders.
+         */
+        'order_admin' => [
+            'sylius_admin_order',
+            'sylius_admin_partial_order',
+            'sylius_admin_customer_order',
+            'sylius_admin_partial_address',
+            'sylius_admin_partial_promotion',
+            'sylius_admin_promotion',
+            'sylius_admin_catalog_promotion',
+            'sylius_admin_partial_shipment',
+            'sylius_admin_ship',
+            'sylius_admin_payment',
+            'sylius_admin_get_payment',
+            'sylius_admin_api_cart',
+        ],
+        'order_shop' => [
+            'sylius_shop_account_order',
+            'sylius_shop_order',
+            'payum_',
+            'sylius_paypal',
+            'sylius_shop_ajax_cart',
+            'sylius_shop_partial_cart',
+            'sylius_shop_cart',
+            'sylius_shop_checkout',
+            'sylius_shop_register_after_checkout',
+        ],
+        'order_api' => [
+            'sylius_admin_api_adjustment',
+            'sylius_admin_api_order',
+            'sylius_admin_api_customer_order',
+            'api_order',
+            'api_adjustment',
+            'sylius_admin_api_promotion',
+            'api_promo',
+            'sylius_admin_api_ship',
+            'api_ship',
+            'sylius_admin_api_payment',
+            'api_pay',
+            'api_cart',
+            'sylius_admin_api_checkout',
+        ],
+        /**
+         * Currencies.
+         */
+        'currency_admin' => [
             'sylius_admin_currency',
             'sylius_admin_api_currency',
+        ],
+        'currency_shop' => [
             'sylius_shop_switch_currency',
+        ],
+        'currency_api' => [
             'api_currencies',
         ],
-
-        // Exchange rates
-        'exchange' => [
+        /**
+         * Exchange rates.
+         */
+        'exchange_admin' => [
             'sylius_admin_exchange',
             'sylius_admin_api_exchange',
             'api_exchange',
         ],
-
-        // Zones
-        'zone' => [
+        'exchange_api' => [
+            'api_exchange',
+        ],
+        /**
+         * Zones.
+         */
+        'zone_admin' => [
             'sylius_admin_zone',
             'sylius_admin_api_zone',
+        ],
+        'zone_api' => [
             'api_zone',
         ],
-
-        // Countries
-        'country' => [
+        /**
+         * Countries.
+         */
+        'country_admin' => [
             'sylius_admin_country',
             'sylius_admin_api_country',
+        ],
+        'country_api' => [
             'api_countries',
         ],
-
-        // Provinces
-        'province' => [
+        /**
+         * Province.
+         */
+        'province_admin' => [
             'sylius_admin_api_province',
             'sylius_admin_ajax_render_province_form',
+        ],
+        'province_api' => [
             'api_province',
         ],
-
-        // Carts
-        'cart' => [
-            'sylius_admin_api_cart',
-            'sylius_shop_ajax_cart',
-            'sylius_shop_partial_cart',
-            'sylius_shop_cart',
-            'api_cart',
-        ],
-
-        // Dashboard
+        /**
+         * Dashboard.
+         */
         'dashboard' => [
             'sylius_admin_dashboard_statistics',
         ],
-
-        // Others
-        'other' => [
+        /**
+         * Billing data.
+         */
+        'billing_data' => [
             'api_shop_billing',
             'api_channels_shop',
         ],

--- a/src/Model/ConfigInterface.php
+++ b/src/Model/ConfigInterface.php
@@ -15,6 +15,187 @@ namespace MonsieurBiz\SyliusNoCommercePlugin\Model;
 
 interface ConfigInterface
 {
+    public const ROUTES_BY_GROUP = [
+        // Customers & Account & Users
+        'customer' => [
+            'sylius_admin_partial_customer',
+            'sylius_admin_customer',
+            'api_customer',
+            'sylius_shop_log',
+            'sylius_shop_register',
+            'sylius_shop_request_password_reset_token',
+            'sylius_shop_password_reset',
+            'sylius_shop_user_request_verification_token',
+            'sylius_shop_user_verification',
+            'sylius_shop_account',
+            'api_register_shop_users_post_collection',
+            'sylius_api_shop_authentication_token',
+            'sylius_shop_ajax_user_check_action',
+        ],
+
+        // Products
+        'product' => [
+            'sylius_admin_product',
+            'sylius_admin_api_product',
+            'sylius_admin_ajax_product',
+            'sylius_shop_partial_product',
+            'sylius_shop_product',
+            'sylius_admin_partial_product',
+            'sylius_admin_ajax_generate_product_slug',
+            'api_product',
+        ],
+
+        // Taxons
+        'taxon' => [
+            'sylius_admin_partial_taxon',
+            'sylius_admin_ajax_taxon',
+            'sylius_admin_taxon',
+            'sylius_admin_api_taxon',
+            'sylius_shop_partial_taxon',
+            'sylius_admin_ajax_generate_taxon_slug',
+            'sylius_shop_partial_channel_menu_taxon_index',
+            'api_taxon',
+        ],
+
+        // Checkout
+        'checkout' => [
+            'sylius_admin_api_checkout',
+            'sylius_shop_checkout',
+            'sylius_shop_register_after_checkout',
+        ],
+
+        // Addresses
+        'address' => [
+            'sylius_shop_account_address',
+            'sylius_admin_partial_address',
+        ],
+
+        // Orders
+        'order' => [
+            'sylius_admin_order',
+            'sylius_admin_api_order',
+            'sylius_shop_account_order',
+            'sylius_shop_order',
+            'sylius_admin_partial_order',
+            'sylius_admin_customer_order',
+            'sylius_admin_api_customer_order',
+            'api_order',
+        ],
+
+        // Adjustments
+        'adjustment' => [
+            'sylius_admin_api_adjustment',
+            'sylius_shop_ajax_render_province_form',
+            'api_adjustment',
+        ],
+
+        // Promotions
+        'promotion' => [
+            'sylius_admin_partial_promotion',
+            'sylius_admin_promotion',
+            'sylius_admin_api_promotion',
+            'sylius_admin_catalog_promotion',
+            'api_promo',
+        ],
+
+        // Shipping and Shipments
+        'shipment' => [
+            'sylius_admin_partial_shipment',
+            'sylius_admin_ship',
+            'sylius_admin_api_ship',
+            'api_ship',
+        ],
+
+        // Inventory
+        'inventory' => [
+            'sylius_admin_inventory',
+        ],
+
+        // Attributes
+        'attribute' => [
+            'sylius_admin_get_attribute_types',
+            'sylius_admin_get_product_attributes',
+            'sylius_admin_render_attribute_forms',
+        ],
+
+        // Payments
+        'payment' => [
+            'sylius_admin_payment',
+            'sylius_admin_get_payment',
+            'payum_',
+            'sylius_admin_api_payment',
+            'api_pay',
+        ],
+
+        // PayPal
+        'paypal' => [
+            'sylius_paypal',
+        ],
+
+        // Taxes
+        'tax' => [
+            'sylius_admin_tax_',
+            'sylius_admin_api_tax_',
+            'api_tax',
+        ],
+
+        // Currencies
+        'currency' => [
+            'sylius_admin_currency',
+            'sylius_admin_api_currency',
+            'sylius_shop_switch_currency',
+            'api_currencies',
+        ],
+
+        // Exchange rates
+        'exchange' => [
+            'sylius_admin_exchange',
+            'sylius_admin_api_exchange',
+            'api_exchange',
+        ],
+
+        // Zones
+        'zone' => [
+            'sylius_admin_zone',
+            'sylius_admin_api_zone',
+            'api_zone',
+        ],
+
+        // Countries
+        'country' => [
+            'sylius_admin_country',
+            'sylius_admin_api_country',
+            'api_countries',
+        ],
+
+        // Provinces
+        'province' => [
+            'sylius_admin_api_province',
+            'sylius_admin_ajax_render_province_form',
+            'api_province',
+        ],
+
+        // Carts
+        'cart' => [
+            'sylius_admin_api_cart',
+            'sylius_shop_ajax_cart',
+            'sylius_shop_partial_cart',
+            'sylius_shop_cart',
+            'api_cart',
+        ],
+
+        // Dashboard
+        'dashboard' => [
+            'sylius_admin_dashboard_statistics',
+        ],
+
+        // Others
+        'other' => [
+            'api_shop_billing',
+            'api_channels_shop',
+        ],
+    ];
+
     public function areCountriesAllowed(): bool;
 
     public function areCustomersAllowed(): bool;

--- a/src/Provider/FeaturesProvider.php
+++ b/src/Provider/FeaturesProvider.php
@@ -20,60 +20,6 @@ use Sylius\Component\Core\Model\ChannelInterface;
 
 final class FeaturesProvider implements FeaturesProviderInterface
 {
-    public const COUNTRIES_KEY = 'countries';
-
-    public const CURRENCIES_KEY = 'currencies';
-
-    public const INVENTORY_KEY = 'inventory';
-
-    public const PAYMENT_KEY = 'payment';
-
-    public const CATALOG_KEY = 'catalog';
-
-    public const SHIPPING_KEY = 'shipping';
-
-    public const TAX_KEY = 'tax';
-
-    public const ZONES_KEY = 'zones';
-
-    public const ADMIN_ROUTES_THAT_CAN_BE_RE_ENABLED = [
-        self::COUNTRIES_KEY => [
-            'sylius_admin_country',
-            'sylius_admin_ajax_render_province_form',
-        ],
-        self::CURRENCIES_KEY => [
-            'sylius_admin_currency',
-        ],
-        self::INVENTORY_KEY => [
-            'sylius_admin_inventory',
-        ],
-        self::PAYMENT_KEY => [
-            'sylius_admin_payment_method',
-        ],
-        self::CATALOG_KEY => [
-            'sylius_admin_get_attribute_types',
-            'sylius_admin_get_product_attributes',
-            'sylius_admin_render_attribute_forms',
-            'sylius_admin_product',
-            'sylius_admin_ajax_product',
-            'sylius_admin_partial_product',
-            'sylius_admin_ajax_generate_product_slug',
-            'sylius_admin_partial_taxon',
-            'sylius_admin_ajax_taxon',
-            'sylius_admin_taxon',
-            'sylius_admin_ajax_generate_taxon_slug',
-        ],
-        self::SHIPPING_KEY => [
-            'sylius_admin_shipping',
-        ],
-        self::TAX_KEY => [
-            'sylius_admin_tax_',
-        ],
-        self::ZONES_KEY => [
-            'sylius_admin_zone',
-        ],
-    ];
-
     private ChannelContextInterface $channelContext;
 
     private SettingsInterface $nocommerceSettings;
@@ -103,36 +49,8 @@ final class FeaturesProvider implements FeaturesProviderInterface
         return (bool) $this->nocommerceSettings->getCurrentValue($channel, null, 'enabled');
     }
 
-    /**
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     */
-    public function isRouteForcedEnabled(array $params = []): bool
+    public function getRoutesToEnable(): array
     {
-        if (!isset($params['_route'])) {
-            return false;
-        }
-
-        $route = $params['_route'];
-        $channel = $this->channelContext->getChannel();
-        /** @var ?array $reEnabledAdminRoutes */
-        $reEnabledAdminRoutes = $this->nocommerceSettings->getCurrentValue($channel, null, 're_enabled_admin_routes');
-
-        if (empty($reEnabledAdminRoutes)) {
-            return false;
-        }
-
-        // We are checking if we should re-enable the route
-        foreach ($reEnabledAdminRoutes as $reEnabledAdminSection) {
-            if (!isset(self::ADMIN_ROUTES_THAT_CAN_BE_RE_ENABLED[$reEnabledAdminSection])) {
-                continue;
-            }
-            foreach (self::ADMIN_ROUTES_THAT_CAN_BE_RE_ENABLED[$reEnabledAdminSection] as $reEnabledAdminRoute) {
-                if (false !== strpos($route, $reEnabledAdminRoute)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return $this->nocommerceSettings->getCurrentValue(null, null, 'routes_to_enable') ?? [];
     }
 }

--- a/src/Provider/FeaturesProviderInterface.php
+++ b/src/Provider/FeaturesProviderInterface.php
@@ -19,5 +19,5 @@ interface FeaturesProviderInterface
 {
     public function isNoCommerceEnabledForChannel(?ChannelInterface $channel = null): bool;
 
-    public function isRouteForcedEnabled(array $params = []): bool;
+    public function getRoutesToEnable(): array;
 }

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -7,5 +7,27 @@ monsieurbiz:
                         label: Firewalls to be disabled
                     enabled:
                         label: Enabled
-                    re_enabled_admin_routes: 
-                        label: Admin routes to re-enable
+                    routes_to_enable: 
+                        label: Route to enable
+            customer: 'Customers'
+            product: 'Products'
+            taxon: 'Taxons'
+            checkout: 'Checkout'
+            address: 'Addresses'
+            order: 'Orders'
+            adjustment: 'Adjustements'
+            promotion: 'Promotions'
+            shipment: 'Shipments'
+            inventory: 'Inventory'
+            attribute: 'Attributes'
+            payment: 'Payments'
+            paypal: 'Paypal'
+            tax: 'Taxes'
+            currency: 'Currencies'
+            exchange: 'Exchanges rates'
+            zone: 'Zones'
+            country: 'Countries'
+            province: 'Provinces'
+            cart: 'Carts'
+            dashboard: 'Dashboard'
+            other: 'Autres'

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -6,28 +6,6 @@ monsieurbiz:
                     disabled_firewall_contexts:
                         label: Firewalls to be disabled
                     enabled:
-                        label: Enabled
+                        label: Enabled, clear cache after modification
                     routes_to_enable: 
-                        label: Route to enable
-            customer: 'Customers'
-            product: 'Products'
-            taxon: 'Taxons'
-            checkout: 'Checkout'
-            address: 'Addresses'
-            order: 'Orders'
-            adjustment: 'Adjustements'
-            promotion: 'Promotions'
-            shipment: 'Shipments'
-            inventory: 'Inventory'
-            attribute: 'Attributes'
-            payment: 'Payments'
-            paypal: 'Paypal'
-            tax: 'Taxes'
-            currency: 'Currencies'
-            exchange: 'Exchanges rates'
-            zone: 'Zones'
-            country: 'Countries'
-            province: 'Provinces'
-            cart: 'Carts'
-            dashboard: 'Dashboard'
-            other: 'Autres'
+                        label: 'Route to enable, clear cache after modification (⚠️ Beta: this feature is under development)'

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -6,28 +6,6 @@ monsieurbiz:
                     disabled_firewall_contexts:
                         label: Firewalls à désactiver
                     enabled:
-                        label: Activer
+                        label: Activer, vider le cache après modification
                     routes_to_enable: 
-                        label: Routes à réactiver
-            customer: 'Clients'
-            product: 'Produits'
-            taxon: 'Taxons'
-            checkout: 'Checkout'
-            address: 'Addresses'
-            order: 'Commandes'
-            adjustment: 'Ajustements'
-            promotion: 'Promotions'
-            shipment: 'Expéditions'
-            inventory: 'Inventaire'
-            attribute: 'Attributs'
-            payment: 'Paiements'
-            paypal: 'Paypal'
-            tax: 'Taxes'
-            currency: 'Devises'
-            exchange: 'Taux de change'
-            zone: 'Zones'
-            country: 'Pays'
-            province: 'Provinces'
-            cart: 'Paniers'
-            dashboard: 'Dashboard'
-            other: 'Autres'
+                        label: 'Routes à réactiver, vider le cache après modification (⚠️ Bêta : cette fonctionnalité est en cours de développement)'

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -7,5 +7,27 @@ monsieurbiz:
                         label: Firewalls à désactiver
                     enabled:
                         label: Activer
-                    re_enabled_admin_routes: 
-                        label: Routes à réactiver pour l'admin
+                    routes_to_enable: 
+                        label: Routes à réactiver
+            customer: 'Clients'
+            product: 'Produits'
+            taxon: 'Taxons'
+            checkout: 'Checkout'
+            address: 'Addresses'
+            order: 'Commandes'
+            adjustment: 'Ajustements'
+            promotion: 'Promotions'
+            shipment: 'Expéditions'
+            inventory: 'Inventaire'
+            attribute: 'Attributs'
+            payment: 'Paiements'
+            paypal: 'Paypal'
+            tax: 'Taxes'
+            currency: 'Devises'
+            exchange: 'Taux de change'
+            zone: 'Zones'
+            country: 'Pays'
+            province: 'Provinces'
+            cart: 'Paniers'
+            dashboard: 'Dashboard'
+            other: 'Autres'

--- a/src/Routing/NoCommerceRequestContext.php
+++ b/src/Routing/NoCommerceRequestContext.php
@@ -41,9 +41,9 @@ final class NoCommerceRequestContext extends BaseRequestContext
         $this->featuresProvider = $featuresProvider;
     }
 
-    public function checkNoCommerce(array $params = []): bool
+    public function checkNoCommerce(): bool
     {
-        return $this->featuresProvider->isNoCommerceEnabledForChannel() && !$this->featuresProvider->isRouteForcedEnabled($params);
+        return $this->featuresProvider->isNoCommerceEnabledForChannel();
     }
 
     /**


### PR DESCRIPTION
Change the way to enable routes by using the array of routes already in plugin.

It's not splitting admin and front route from now, but it can be managed later.

