### PR TITLE
Add missing channelPriceHistoryConfig field to management in channel form for Sylius 1.13

### DIFF
--- a/src/Form/Extension/ChannelTypeExtension.php
+++ b/src/Form/Extension/ChannelTypeExtension.php
@@ -56,6 +56,7 @@ final class ChannelTypeExtension extends AbstractTypeExtension
             ->remove('currencies')
             ->remove('defaultTaxZone')
             ->remove('taxCalculationStrategy')
+            ->remove('channelPriceHistoryConfig')
             ->addEventSubscriber(new RemoveBaseCurrencySubscriber())
         ;
     }

--- a/src/Resources/views/Admin/Channel/_noCommerceForm.html.twig
+++ b/src/Resources/views/Admin/Channel/_noCommerceForm.html.twig
@@ -80,5 +80,10 @@
             {#            {{ form_row(form.skippingPaymentStepAllowed) }}#}
             {{ form_row(form.accountVerificationRequired) }}
         </div>
+{#        <div class="ui attached segment">#}
+{#            {{ form_row(form.channelPriceHistoryConfig.lowestPriceForDiscountedProductsVisible) }}#}
+{#            {{ form_row(form.channelPriceHistoryConfig.lowestPriceForDiscountedProductsCheckingPeriod) }}#}
+{#            {{ form_row(form.channelPriceHistoryConfig.taxonsExcludedFromShowingLowestPrice, {'remote_url': path('sylius_admin_ajax_taxon_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_taxon_by_code')}) }}#}
+{#        </div>#}
     </div>
 </div>

--- a/src/Resources/views/Admin/Channel/_standardForm.html.twig
+++ b/src/Resources/views/Admin/Channel/_standardForm.html.twig
@@ -80,5 +80,12 @@
             {{ form_row(form.skippingPaymentStepAllowed) }}
             {{ form_row(form.accountVerificationRequired) }}
         </div>
+        {% if form.channelPriceHistoryConfig is defined %}
+            <div class="ui attached segment">
+                {{ form_row(form.channelPriceHistoryConfig.lowestPriceForDiscountedProductsVisible) }}
+                {{ form_row(form.channelPriceHistoryConfig.lowestPriceForDiscountedProductsCheckingPeriod) }}
+                {{ form_row(form.channelPriceHistoryConfig.taxonsExcludedFromShowingLowestPrice, {'remote_url': path('sylius_admin_ajax_taxon_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_taxon_by_code')}) }}
+            </div>
+        {% endif %}
     </div>
 </div>


### PR DESCRIPTION
This is a new field in Sylius 1.13. 

## Tests

|Version|No commerce enabled|No commerce disabled|
|-|-|-|
|Sylius 1.12|![image](https://github.com/user-attachments/assets/6626c5b2-7b13-4900-9971-77030eb3392b)|![image](https://github.com/user-attachments/assets/cbd40e7d-4054-4c15-99b0-42fb79d40609)|
|Sylius 1.13|![image](https://github.com/user-attachments/assets/3abbef7a-cd16-4a5b-a550-6721e4e9156d)|![image](https://github.com/user-attachments/assets/5cb7ac2d-3b8e-4543-892b-610f977a24f3)|

